### PR TITLE
Fix parsing of "service: name" style.

### DIFF
--- a/goserverless_test.go
+++ b/goserverless_test.go
@@ -1,6 +1,9 @@
 package goserverless_test
 
 import (
+	"io/ioutil"
+	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/thepauleh/goserverless"
@@ -13,9 +16,52 @@ var _ = Describe("GoServerless", func() {
 
 		It("should read basic params", func() {
 			Expect(err).To(BeNil())
+			Expect(importedTemplate).To(Not(BeNil()))
 
 			Expect(importedTemplate.Service.Name).To(Equal("basicService"))
 			Expect(importedTemplate.FrameworkVersion).To(Equal(">=1.0.0 <2.1.9"))
+		})
+
+		It("should roundtrip without error", func() {
+			bytes, err := importedTemplate.YAML()
+			Expect(err).To(BeNil())
+			file, err := ioutil.TempFile("", "goformation")
+			defer os.Remove(file.Name())
+			Expect(err).To(BeNil())
+			_, err = file.Write(bytes)
+			Expect(err).To(BeNil())
+			err = file.Close()
+			Expect(err).To(BeNil())
+			roundtripTemplate, err := goserverless.Open(file.Name())
+			Expect(err).To(BeNil())
+			Expect(roundtripTemplate).To(Not(BeNil()))
+		})
+	})
+
+	Context("Transform and hydrate a serverless config with a string service value back to our structs", func() {
+		importedTemplate, err := goserverless.Open("test/yaml/service-just-name.yaml")
+
+		It("should read basic params", func() {
+			Expect(err).To(BeNil())
+			Expect(importedTemplate).To(Not(BeNil()))
+
+			Expect(importedTemplate.Service.Name).To(Equal("basicService"))
+			Expect(importedTemplate.FrameworkVersion).To(Equal(">=1.0.0 <2.1.9"))
+		})
+
+		It("should roundtrip without error", func() {
+			bytes, err := importedTemplate.YAML()
+			Expect(err).To(BeNil())
+			file, err := ioutil.TempFile("", "goformation")
+			defer os.Remove(file.Name())
+			Expect(err).To(BeNil())
+			_, err = file.Write(bytes)
+			Expect(err).To(BeNil())
+			err = file.Close()
+			Expect(err).To(BeNil())
+			roundtripTemplate, err := goserverless.Open(file.Name())
+			Expect(err).To(BeNil())
+			Expect(roundtripTemplate).To(Not(BeNil()))
 		})
 	})
 
@@ -24,12 +70,14 @@ var _ = Describe("GoServerless", func() {
 
 		It("should get the imported template", func() {
 			Expect(err).To(BeNil())
+			Expect(importedTemplate).To(Not(BeNil()))
 		})
 		// Start Testing the function events!
 		usersCreateFunction := importedTemplate.Functions["usersCreate"]
 
 		It("should read basic params", func() {
 			Expect(err).To(BeNil())
+			Expect(importedTemplate).To(Not(BeNil()))
 
 			Expect(importedTemplate.Service.Name).To(Equal("myService"))
 			Expect(importedTemplate.FrameworkVersion).To(Equal(">=1.0.0 <2.0.0"))
@@ -191,6 +239,21 @@ var _ = Describe("GoServerless", func() {
 
 		It("Should pull out the resource policy", func() {
 			Expect(importedTemplate.Provider.ResourcePolicy).ShouldNot(BeNil())
+		})
+
+		It("should roundtrip without error", func() {
+			bytes, err := importedTemplate.YAML()
+			Expect(err).To(BeNil())
+			file, err := ioutil.TempFile("", "goformation")
+			defer os.Remove(file.Name())
+			Expect(err).To(BeNil())
+			_, err = file.Write(bytes)
+			Expect(err).To(BeNil())
+			err = file.Close()
+			Expect(err).To(BeNil())
+			roundtripTemplate, err := goserverless.Open(file.Name())
+			Expect(err).To(BeNil())
+			Expect(roundtripTemplate).To(Not(BeNil()))
 		})
 	})
 })

--- a/serverless/service.go
+++ b/serverless/service.go
@@ -1,7 +1,44 @@
 package serverless
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // Service is the Serverless Service definition
 type Service struct {
-	Name         string `json:"name,omitempty"`
-	AwsKmsKeyArn string `json:"awsKmsKeyArn,omitempty"`
+	Name         string
+	AwsKmsKeyArn string
 }
+
+func (s *Service) UnmarshalJSON(data []byte) error {
+	// From Unmarshaler doc, []byte("null") is a no-op.
+	if string(data) == "null" {
+		return nil
+	}
+	var service interface{}
+	if err := json.Unmarshal(data, &service); err != nil {
+		return err
+	}
+	switch service.(type){
+	case string:
+		s.Name = service.(string)
+	case map[string]interface{}:
+		serviceMap := service.(map[string]interface{})
+		s.Name = serviceMap["name"].(string)
+		if serviceMap["awsKmsKeyArn"] != nil {
+			s.AwsKmsKeyArn = serviceMap["awsKmsKeyArn"].(string)
+		}
+	default:
+		return fmt.Errorf("unable to parse %s as service data", string(data))
+	}
+	return nil
+}
+
+func (s *Service) MarshalJSON() ([]byte, error) {
+	if len(s.AwsKmsKeyArn) == 0 {
+		return []byte(fmt.Sprintf(`"%s"`, s.Name)), nil
+	}
+	return json.Marshal(map[string]string{"name": s.Name, "awsKmsKeyArn": s.AwsKmsKeyArn})
+}
+

--- a/test/yaml/service-just-name.yaml
+++ b/test/yaml/service-just-name.yaml
@@ -1,0 +1,3 @@
+service: basicService
+
+frameworkVersion: ">=1.0.0 <2.1.9"


### PR DESCRIPTION
The example in README.md shows a common format for the service key:

    service: example

rather than the previously supported:

    service:
        name: example

Service now implements json.Marshaler and json.Unmarshaler to handle this case.