### PR TITLE
Don't cast directly as it fails for deploymentBucket

### DIFF
--- a/serverless/provider.go
+++ b/serverless/provider.go
@@ -35,6 +35,7 @@ type Provider struct {
 type DeploymentBucket struct {
 	Name                 string `json:"name,omitempty"`
 	ServerSideEncryption string `json:"serverSideEncryption,omitempty"`
+	blockPublicAccess    bool   `json:"blockPublicAccess,omitempty"`
 }
 
 type Tracing struct {
@@ -71,9 +72,15 @@ func (d *DeploymentBucket) UnmarshalJSON(bytes []byte) error {
 	case string:
 		d.Name = db.(string)
 	case map[string]interface{}:
-		deploymentObj := db.(DeploymentBucket)
-		d.ServerSideEncryption = deploymentObj.ServerSideEncryption
-		d.Name = deploymentObj.Name
+		if val, ok := db.(map[string]interface{})["name"]; ok {
+			d.Name = val.(string)
+		}
+		if val, ok := db.(map[string]interface{})["serverSideEncryption"]; ok {
+			d.ServerSideEncryption = val.(string)
+		}
+		if val, ok := db.(map[string]interface{})["blockPublicAccess"]; ok {
+			d.blockPublicAccess = val.(bool)
+		}
 	default:
 		return fmt.Errorf("unable to parse provider.tracing")
 	}


### PR DESCRIPTION
goserverless failed to parse a deployment object as it threw an exception when casting.
The file below is an example of one that was fail and now can be parsed with this change: 
`provider:
  name: aws
  stage: ${opt:stage, 'dev'}
  region: ${opt:region, 'us-east-1' }
  logRetentionInDays: 14
  timeout: 10
  stackName: lambda-${self:service.name}
  tag: ${opt:tag}
  deploymentBucket: 
    name: anyoldname
    blockPublicAccess: true
    serverSideEncryption: AES256`